### PR TITLE
bug fix - remove upstream from guardrails package

### DIFF
--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/constraint.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/constraint.yaml
@@ -16,8 +16,6 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: DataLocation
 metadata: # kpt-merge: /datalocation
   name: datalocation
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'constraints.gatekeeper.sh|DataLocation|default|datalocation'
 spec:
   match:
     kinds:

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/suite.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/suite.yaml
@@ -18,7 +18,6 @@ metadata: # kpt-merge: /datalocation
   name: datalocation
   annotations:
     config.kubernetes.io/local-config: 'true'
-    internal.kpt.dev/upstream-identifier: 'test.gatekeeper.sh|Suite|default|datalocation'
 tests:
 - name: datalocation
   template: template.yaml

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/template.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/05-data-location/template.yaml
@@ -19,7 +19,6 @@ metadata: # kpt-merge: /datalocation
   annotations:
     description: Establish policies to restrict GC sensitive workloads to approved geographic locations.
     reference: https://github.com/canada-ca/cloud-guardrails/blob/master/EN/05_Data-Location.md
-    internal.kpt.dev/upstream-identifier: 'templates.gatekeeper.sh|ConstraintTemplate|default|datalocation'
 spec:
   crd:
     spec:

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/constraint.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/constraint.yaml
@@ -16,8 +16,6 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: LimitEgressTraffic
 metadata: # kpt-merge: /limitegresstraffic
   name: limitegresstraffic
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'constraints.gatekeeper.sh|LimitEgressTraffic|default|limitegresstraffic'
 spec:
   match:
     kinds:

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/suite.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/suite.yaml
@@ -18,7 +18,6 @@ metadata: # kpt-merge: /limitegresstraffic
   name: limitegresstraffic
   annotations:
     config.kubernetes.io/local-config: 'true'
-    internal.kpt.dev/upstream-identifier: 'test.gatekeeper.sh|Suite|default|limitegresstraffic'
 tests:
 - name: limitegresstraffic
   template: template.yaml

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/template.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/09-network-security-services/template.yaml
@@ -20,7 +20,6 @@ metadata: # kpt-merge: /limitegresstraffic
     description: Establish external and internal network perimeters and monitor network traffic.
     reference: https://github.com/canada-ca/cloud-guardrails/blob/master/EN/09_Network-Security-Services.md
     related-security-controls: AC-3, AC‑4, SC-5, SC‑7, SC‑7(5), SI-3, SI-3(7), SI-4
-    internal.kpt.dev/upstream-identifier: 'templates.gatekeeper.sh|ConstraintTemplate|default|limitegresstraffic'
 spec:
   crd:
     spec:
@@ -41,7 +40,7 @@ spec:
           input.review.kind.kind == "ContainerCluster"
           not has_key(input.review.object.spec, "privateClusterConfig")
           msg := sprintf("GKE is not Private %s", [input.review.object.metadata.name])
-        }
+        }          
 
         # Ensure Services do not configure External IPs
         # IE Private GKE Cluster
@@ -71,7 +70,7 @@ spec:
           input.review.kind.kind == "StorageBucket"
           not has_key(input.review.object.spec, "publicAccessPrevention")
           msg := sprintf("Bucket is not Private %s", [input.review.object.metadata.name])
-        }
+        }        
 
         violation[{"msg":msg}] {
           input.review.kind.kind == "StorageBucket"

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/constraint.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/constraint.yaml
@@ -16,8 +16,6 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: CloudMarketPlaceConfig
 metadata: # kpt-merge: /cloudmarketplaceconfig
   name: cloudmarketplaceconfig
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'constraints.gatekeeper.sh|CloudMarketPlaceConfig|default|cloudmarketplaceconfig'
 spec:
   match:
     kinds:

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/suite.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/suite.yaml
@@ -18,8 +18,6 @@ metadata: # kpt-merge: /cloudmarketplaceconfig
   name: cloudmarketplaceconfig
   annotations:
     config.kubernetes.io/local-config: 'true'
-    config.kubernetes.io/local-config: 'true'
-    internal.kpt.dev/upstream-identifier: 'test.gatekeeper.sh|Suite|default|cloudmarketplaceconfig'
 tests:
 - name: limitegresstraffic
   template: template.yaml

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/template.yaml
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/12-cloud-market-place/template.yaml
@@ -20,7 +20,6 @@ metadata: # kpt-merge: /cloudmarketplaceconfig
     description: Restrict Third-Party CSP Marketplace software to GC-approved products.
     reference: https://github.com/canada-ca/cloud-guardrails/blob/master/EN/12_Cloud-Marketplace-Config.md
     related-security-controls: CM‑2, CM‑3, CM‑4, CM‑5, CM‑8, SA‑22
-    internal.kpt.dev/upstream-identifier: 'templates.gatekeeper.sh|ConstraintTemplate|default|cloudmarketplaceconfig'
 spec:
   crd:
     spec:

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/Kptfile
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/Kptfile
@@ -1,6 +1,0 @@
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: guardrails
-info:
-  description: sample description

--- a/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/Kptfile
+++ b/solutions/landing-zone-namespaced/gatekeeper-policies/guardrails/Kptfile
@@ -2,19 +2,5 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: guardrails
-upstream:
-  type: git
-  git:
-    repo: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit
-    directory: /solutions/guardrails-policies
-    ref: main
-  updateStrategy: resource-merge
-upstreamLock:
-  type: git
-  git:
-    repo: https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit
-    directory: /solutions/guardrails-policies
-    ref: main
-    commit: 4b9212f7e20d51f20e129a1e9853aa9b7f6272e6
 info:
   description: sample description


### PR DESCRIPTION
removed upstream from `solutions/landing-zone-namespaced/gatekeeper-policies/guardrails`

https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/guardrails-policies contained formatting issues and duplicate yaml keys

the files from https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/landing-zone/environments/common/guardrails-policies were copied instead as they appear to be fixed